### PR TITLE
Respect :CUSTOM_ID in headlines

### DIFF
--- a/ox-rss.el
+++ b/ox-rss.el
@@ -244,7 +244,9 @@ communication channel."
 	     (hl-home (file-name-as-directory (plist-get info :html-link-home)))
 	     (hl-pdir (plist-get info :publishing-directory))
 	     (hl-perm (org-element-property :RSS_PERMALINK headline))
-	     (anchor (org-export-get-reference headline info))
+	     (anchor
+              (or (org-element-property :CUSTOM_ID headline)
+                  (org-export-get-reference headline info)))
 	     (category (org-rss-plain-text
 			(or (org-element-property :CATEGORY headline) "") info))
 	     (pubdate0 (org-element-property :PUBDATE headline))


### PR DESCRIPTION
Using org-export-get-reference generates a new reference number on export. This changes the <link> tag in the xml file. A feed reader (e.g. elfeed) thinks this updates the entry and shows it as an new entry to its users.